### PR TITLE
Add failing test case for $stdout = StringIO

### DIFF
--- a/spec/io_spec.rb
+++ b/spec/io_spec.rb
@@ -1,7 +1,17 @@
 require File.expand_path('../spec_helper', __FILE__)
 
 describe ChildProcess do
- it "can redirect stdout, stderr" do
+  it "can run even when $stdout is a StringIO" do
+    begin
+      stdout = $stdout
+      $stdout = StringIO.new
+      expect { sleeping_ruby.start }.to_not raise_error
+    ensure
+      $stdout = stdout
+    end
+  end
+
+  it "can redirect stdout, stderr" do
     process = ruby(<<-CODE)
       [STDOUT, STDERR].each_with_index do |io, idx|
         io.sync = true


### PR DESCRIPTION
I ran into a problem where something during a CI build was setting `$stdout` to a `StringIO`, which has `#fileno` defined as `nil`, causing "TypeError: no implicit conversion from nil to integer"

The problem seems to be the `fileno_for` call here: https://github.com/jarib/childprocess/blob/master/lib/childprocess/unix/posix_spawn_process.rb#L17, which calls `#fileno` on the `StringIO` here: https://github.com/jarib/childprocess/blob/master/lib/childprocess/unix/posix_spawn_process.rb#L84, gets `nil`, then blows up.

This only happens when using POSIX spawn, fork and exec is fine.

I'm not actually sure how to fix this, but I've added a failing test case.