### PR TITLE
Shut down the test processes

### DIFF
--- a/spec/unix_spec.rb
+++ b/spec/unix_spec.rb
@@ -18,6 +18,8 @@ if ChildProcess.unix? && !ChildProcess.jruby? && !ChildProcess.posix_spawn?
       expect { process.stop }.not_to raise_error
 
       allow(process).to receive(:alive?).and_return(false)
+
+      process.send(:send_signal, 'TERM')
     end
 
     it "handles ESRCH race condition where process dies between timeout and KILL" do
@@ -32,6 +34,8 @@ if ChildProcess.unix? && !ChildProcess.jruby? && !ChildProcess.posix_spawn?
       expect { process.stop }.not_to raise_error
 
       allow(process).to receive(:alive?).and_return(false)
+
+      process.send(:send_signal, 'TERM')
     end
   end
 


### PR DESCRIPTION
We've mocked out the shutdown methods, so that we could test their error
handling behavior. But we still need to clean up after ourselves.

Fixes: https://bugs.debian.org/747847